### PR TITLE
Added 60dB integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@
 # Get your key from: https://console.deepgram.com/
 DEEPGRAM_API_KEY="your_deepgram_api_key_here"
 
+# 60db API key for Speech-to-Text (optional alternative STT engine)
+# Selectable per-interview from the AI Setup tab. Leave blank if unused.
+# Get your key from: https://60db.ai/
+SIXTYDB_API_KEY=""
+
 # ----- Logging -----
 # Logging level (DEBUG, INFO, WARNING, ERROR)
 LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ When combined with Stealth Mode, Vision AI becomes even more potent:
 
 ### 🎤 **Real-Time Voice Intelligence (Completely Stealthy)**
 
-- **Live Transcription** — Deepgram-powered, high-accuracy speech-to-text with continuous streaming. Captures both interviewer questions and your responses in real-time
+- **Selectable STT Engine** — Choose your real-time transcription engine per session: **Deepgram** (Nova-3) or **60db**. Pick it from the AI Setup tab — both stream over WebSockets and feed the exact same coaching pipeline
+- **Live Transcription** — High-accuracy speech-to-text with continuous streaming. Captures both interviewer questions and your responses in real-time
 - **Context-Aware Coaching** — Aura knows your resume, job description, target role, and the full conversation history. Every response is hyper-personalized to *you* and the specific question being asked
 - **Conversation Memory** — Remembers the entire interview (configurable up to 20 exchanges) for cross-referencing past questions, detecting follow-ups, and maintaining consistent narrative
 - **Candidate Response Tracking** — Optionally tracks what you say so Aura can provide follow-up suggestions, catch mistakes, and help you build on previous answers
@@ -342,7 +343,8 @@ This diagram illustrates Aura's multi-layered architecture—designed for real-t
 | **Config API** | `api/config_api.py` | REST endpoints for settings, providers, transparency |
 | **Session manager** | `api/session_manager.py` | Interview lifecycle and state management |
 | **LLM service** | `services/llm_service.py` | Multi-provider AI with key rotation, failover, health checks |
-| **STT service** | `services/stt_service.py` | Deepgram real-time transcription with auto-reconnect |
+| **STT service (Deepgram)** | `services/stt_service.py` | Deepgram Nova-3 real-time transcription with auto-reconnect |
+| **STT service (60db)** | `services/sixtydb_stt_service.py` | 60db WebSocket transcription — drop-in alternative with the same interface |
 | **Vision service** | `services/vision_service.py` | Screenshot analysis with auto content-type detection |
 | **Context manager** | `services/context_manager.py` | Persistent profile, resume, JD, conversation history |
 | **Prompts** | `core/prompts.py` | AI system prompts and expert coaching instructions |
@@ -488,7 +490,20 @@ Deepgram is the **core engine** that powers Aura's real-time transcription. It l
 |---|---------|
 | **Sign up** | [console.deepgram.com](https://console.deepgram.com/) |
 | **Free tier** | **$200 in credits** — enough for ~100+ hours of transcription |
-| **Why it's required** | Core STT engine — powers all voice intelligence features |
+| **Why it's required** | Default STT engine — powers all voice intelligence features |
+
+> **🔁 Prefer a different STT engine?** Aura also supports **60db** as a selectable alternative to Deepgram — see below. At least **one** STT engine (Deepgram **or** 60db) must be configured.
+
+### 🎙️ 60db (Optional — Alternative Speech-to-Text Engine)
+
+60db is a selectable alternative to Deepgram for real-time transcription. Add your key, then choose **60db** as the Speech-to-Text Engine in the AI Setup tab. It streams over a WebSocket and feeds the identical coaching pipeline — including the same programming/technical keyword boosting Deepgram uses.
+
+| | Details |
+|---|---------|
+| **Sign up** | [60db.ai](https://60db.ai/) |
+| **API key** | Stored as `SIXTYDB_API_KEY` in `.env` (set it in the **Advanced Config** tab) |
+| **Engine** | Real-time WebSocket STT (`wss://api.60db.ai/ws/stt`), 16-bit PCM @ 48 kHz |
+| **How to select** | AI Setup tab → **Speech-to-Text Engine** → `60db` |
 
 ### ⚡ Cerebras (Recommended — Fastest Text AI)
 
@@ -565,7 +580,8 @@ The app **auto-creates** `.env` from `.env.example` on first run.
 
 ```env
 # ─── API Keys ───
-DEEPGRAM_API_KEY="your_key"              # Required — Deepgram speech-to-text
+DEEPGRAM_API_KEY="your_key"              # Deepgram speech-to-text (default STT engine)
+SIXTYDB_API_KEY=""                       # 60db speech-to-text (optional alternative STT engine)
 
 # ─── Logging ───
 LOG_LEVEL=INFO                            # DEBUG, INFO, WARNING, ERROR
@@ -716,7 +732,7 @@ SCROLL_INTERVAL_MS=70    # Higher = less frequent
 | **Runtime** | Python 3.8+, asyncio |
 | **Web framework** | FastAPI + Uvicorn |
 | **Desktop shell** | pywebview (WinForms backend) |
-| **Speech-to-text** | Deepgram SDK v3 |
+| **Speech-to-text** | Deepgram SDK v3 **or** 60db (`websockets`) — selectable per session |
 | **LLM clients** | OpenAI-compatible SDK (Groq, Cerebras, Gemini, OpenRouter) |
 | **Global hotkeys** | pynput |
 | **Win32 integration** | ctypes — capture protection, transparency, window management |

--- a/api/config_api.py
+++ b/api/config_api.py
@@ -129,6 +129,24 @@ async def save_deepgram_key(request: SaveKeyRequest):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error saving Deepgram key: {e}")
 
+@router.get("/api/sixtydb-key")
+async def get_sixtydb_key():
+    """Retrieves the current SIXTYDB_API_KEY from .env."""
+    key = env_manager.get_value("SIXTYDB_API_KEY")
+    return {"key": key or ""}
+
+@router.post("/api/save-sixtydb-key")
+async def save_sixtydb_key(request: SaveKeyRequest):
+    """Updates the SIXTYDB_API_KEY in the .env file."""
+    try:
+        success = env_manager.update_key("SIXTYDB_API_KEY", request.key)
+        if success:
+            return {"success": True, "message": "60db API key saved successfully"}
+        else:
+            raise HTTPException(status_code=500, detail="Failed to update .env file")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error saving 60db key: {e}")
+
 @router.post("/api/verify-provider")
 async def verify_ai_provider(request: ProviderVerifyRequest):
     """

--- a/api/session_manager.py
+++ b/api/session_manager.py
@@ -51,6 +51,24 @@ class InterviewSession:
         print(f"⬅️ [BACKEND] Sending 'api_key_status' for Deepgram. Valid: {is_valid}")
         await self._send_json("api_key_status", {"service": "deepgram", "valid": is_valid})
 
+    async def handle_verify_stt(self, payload: dict):
+        """Verifies the API key for the selected STT engine (deepgram or sixtydb)."""
+        self._touch()
+        engine = payload.get('engine', 'deepgram')
+        print(f"➡️ [BACKEND] Received 'verify_stt' (engine={engine}) for session {self.session_id}")
+
+        if engine == 'sixtydb':
+            from services.sixtydb_stt_service import verify_sixtydb_api_key
+            is_valid = await verify_sixtydb_api_key()
+            service = "sixtydb"
+        else:
+            from services.stt_service import verify_deepgram_api_key
+            is_valid = await verify_deepgram_api_key()
+            service = "deepgram"
+
+        print(f"⬅️ [BACKEND] Sending 'api_key_status' for {service}. Valid: {is_valid}")
+        await self._send_json("api_key_status", {"service": service, "valid": is_valid})
+
     async def handle_start_interview(self, payload: dict):
         """Handles the 'start_interview' message."""
         self._touch()
@@ -61,12 +79,13 @@ class InterviewSession:
             primary_vision_config = payload.get('visionProvider')
             secondary_vision_config = payload.get('visionSecondaryProvider')
             onboarding_context = payload.get('onboardingData', {})
-            
+            stt_engine = payload.get('stt_engine', 'deepgram')
+
             self.state["is_muted"] = payload.get('is_muted', False)
             self.state["process_all_speakers"] = payload.get('process_all_speakers', True)
             self.state["is_universally_muted"] = payload.get('is_universally_muted', False)
 
-            await self.initialize_managers(primary_provider_config, secondary_provider_config, primary_vision_config, secondary_vision_config, onboarding_context)
+            await self.initialize_managers(primary_provider_config, secondary_provider_config, primary_vision_config, secondary_vision_config, onboarding_context, stt_engine)
             
             current_preset = self.llm_manager.get_current_preset_info()
             health_results = await self.llm_manager.perform_health_checks()
@@ -188,7 +207,7 @@ class InterviewSession:
         await self._send_json("session_reset_complete", {"status": "ok"})
         print(f"✅ Session {self.session_id}: Context has been reset.")
 
-    async def initialize_managers(self, primary_provider_config, secondary_provider_config, primary_vision_config, secondary_vision_config, onboarding_context):
+    async def initialize_managers(self, primary_provider_config, secondary_provider_config, primary_vision_config, secondary_vision_config, onboarding_context, stt_engine='deepgram'):
         """Initializes all necessary managers for the session."""
         self.llm_manager = MultiLLMManager()
         config_loaded = self.llm_manager.load_configuration(
@@ -208,9 +227,15 @@ class InterviewSession:
         )
 
         user_languages = onboarding_context.get('selectedLanguages', [])
-        self.stt_manager = DeepgramManager(self.on_transcript, user_languages)
+        if stt_engine == 'sixtydb':
+            from services.sixtydb_stt_service import SixtyDBManager
+            self.stt_manager = SixtyDBManager(self.on_transcript, user_languages)
+            print(f"🎙️ Session {self.session_id}: STT engine = 60db")
+        else:
+            self.stt_manager = DeepgramManager(self.on_transcript, user_languages)
+            print(f"🎙️ Session {self.session_id}: STT engine = Deepgram")
         await self.stt_manager.start()
-        
+
         self.is_active = True
 
     async def _process_aggregated_transcript(self):

--- a/core/config.py
+++ b/core/config.py
@@ -9,8 +9,11 @@ class Settings(BaseSettings):
     """
     # Required API Keys (no defaults - must be provided)
     DEEPGRAM_API_KEY: str
-    
-    
+
+    # Optional API Keys (default empty so the app still starts if unset)
+    # 60db is a selectable alternative speech-to-text engine alongside Deepgram.
+    SIXTYDB_API_KEY: str = ""
+
     # Logging Configuration
     LOG_LEVEL: str = "INFO"
     
@@ -69,3 +72,4 @@ def print_config_debug():
     print(f"      GENERATE_FULL_ANSWERS = {settings.GENERATE_FULL_ANSWERS}")
     print(f"      PERSONALIZE_ANSWERS = {settings.PERSONALIZE_ANSWERS}")
     print(f"   🔑 API Keys: DEEPGRAM={'*' * 20 if settings.DEEPGRAM_API_KEY else 'Not Set'}")
+    print(f"   🔑 API Keys: 60DB={'*' * 20 if settings.SIXTYDB_API_KEY else 'Not Set'}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ orjson
 aiofiles
 pynput
 python-dotenv
+websockets

--- a/services/sixtydb_stt_service.py
+++ b/services/sixtydb_stt_service.py
@@ -1,0 +1,299 @@
+import asyncio
+import base64
+import json
+
+import websockets
+
+from core.config import settings
+from services.stt_service import build_programming_keyterms
+
+# 60db real-time STT WebSocket endpoint (wss for security).
+# Auth is via the apiKey query parameter, per the 60db WebSocket STT spec.
+SIXTYDB_WS_URL = "wss://api.60db.ai/ws/stt"
+
+# The browser AudioWorklet emits 16-bit signed little-endian mono PCM, and the
+# Deepgram path is hardcoded to 48 kHz. We mirror that exactly so both engines
+# consume the identical audio stream — 60db's "linear" encoding == raw PCM16.
+SIXTYDB_SAMPLE_RATE = 48000
+
+
+async def verify_sixtydb_api_key():
+    """
+    Verifies the 60db API key by opening the STT WebSocket and waiting for the
+    `connection_established` handshake. This also implicitly validates that the
+    workspace has a sufficient credit balance (the server closes with code 1008
+    otherwise). Mirrors `verify_deepgram_api_key` in intent.
+    Returns True if the key is valid, False otherwise.
+    """
+    if not settings.SIXTYDB_API_KEY:
+        return False
+
+    url = f"{SIXTYDB_WS_URL}?apiKey={settings.SIXTYDB_API_KEY}"
+    try:
+        ws = await asyncio.wait_for(websockets.connect(url, max_size=None), timeout=10)
+    except Exception as e:
+        print(f"ERROR: 60db API key verification failed to connect: {e}")
+        return False
+
+    try:
+        raw = await asyncio.wait_for(ws.recv(), timeout=10)
+        msg = json.loads(raw)
+        if "connection_established" in msg:
+            print("INFO: 60db API key is valid.")
+            return True
+        if "error" in msg or msg.get("type") == "error":
+            print(f"ERROR: 60db verification returned error: {msg}")
+            return False
+        # Any other well-formed first message still implies an authenticated socket.
+        return True
+    except Exception as e:
+        print(f"ERROR: A problem occurred while verifying 60db key: {e}")
+        return False
+    finally:
+        try:
+            await ws.close()
+        except Exception:
+            pass
+
+
+class SixtyDBManager:
+    """
+    Manages a connection to 60db for live transcription.
+
+    This is a drop-in alternative to `DeepgramManager`: it exposes the same
+    public surface used by the session layer — `start()`, `send_audio()` and
+    `finish()` — and invokes `transcript_callback` with the identical
+    `{speaker, transcript, is_final}` contract so the rest of the app does not
+    need to know which engine is active.
+    """
+
+    def __init__(self, transcript_callback, user_languages=None):
+        self.transcript_callback = transcript_callback
+        self.user_languages = user_languages or []
+        self.ws = None
+        self.is_connected = False  # True only once the session is ready for audio
+        self.stop_event = asyncio.Event()
+        self.sample_rate = SIXTYDB_SAMPLE_RATE
+        self._recv_task = None
+        self._reconnect_attempts = 0
+        self._max_reconnect_attempts = 5
+        self._reconnect_base_delay = 1.0  # seconds
+
+    async def start(self):
+        """Opens the 60db connection and begins the transcription session."""
+        if not settings.SIXTYDB_API_KEY:
+            print("❌ ERROR: SIXTYDB_API_KEY is not set; cannot start 60db STT.")
+            return
+
+        self.stop_event.clear()
+        url = f"{SIXTYDB_WS_URL}?apiKey={settings.SIXTYDB_API_KEY}"
+
+        try:
+            self.ws = await asyncio.wait_for(websockets.connect(url, max_size=None), timeout=10)
+        except Exception as e:
+            print(f"❌ ERROR: Could not connect to 60db: {e}")
+            asyncio.create_task(self._reconnect())
+            return
+
+        # The spec requires waiting for `connection_established` before sending `start`.
+        try:
+            raw = await asyncio.wait_for(self.ws.recv(), timeout=10)
+            handshake = json.loads(raw)
+        except Exception as e:
+            print(f"❌ ERROR: 60db handshake failed: {e}")
+            await self._safe_close()
+            asyncio.create_task(self._reconnect())
+            return
+
+        if "connection_established" not in handshake:
+            print(f"❌ ERROR: Unexpected 60db handshake message: {handshake}")
+            await self._safe_close()
+            return
+        print("🔗 60db connection established")
+
+        # Reuse the same boosted vocabulary as Deepgram. 60db surfaces up to ~30
+        # terms to its LLM refinement pass, so we keep the list compact.
+        terms = build_programming_keyterms(self.user_languages)[:30]
+
+        start_msg = {
+            "type": "start",
+            # Spoken language is English, matching the Deepgram path (language="en").
+            "languages": ["en"],
+            "config": {
+                "encoding": "linear",
+                "sample_rate": self.sample_rate,
+                "utterance_end_ms": 1000,       # mirror Deepgram's utterance_end_ms
+                "continuous_mode": True,
+                "interim_results_frequency": 300,
+                "audio_enhancement": "adaptive",
+            },
+        }
+        if terms:
+            start_msg["context"] = {"terms": terms}
+
+        try:
+            await self.ws.send(json.dumps(start_msg))
+        except Exception as e:
+            print(f"❌ ERROR: Failed to send 60db start message: {e}")
+            await self._safe_close()
+            asyncio.create_task(self._reconnect())
+            return
+
+        # Begin reading server events. `session_started` flips is_connected on.
+        self._recv_task = asyncio.create_task(self._receive_loop())
+        # Safety net: if the server doesn't emit an explicit session-started ack
+        # (key naming varies), enable audio after a short grace period anyway.
+        asyncio.create_task(self._enable_audio_fallback())
+        self._reconnect_attempts = 0
+        print("✅ 60db STT session starting...")
+
+    async def _enable_audio_fallback(self):
+        await asyncio.sleep(1.5)
+        if not self.is_connected and not self.stop_event.is_set() and self.ws:
+            print("⚠️ 60db: no explicit session_started ack — enabling audio anyway")
+            self.is_connected = True
+
+    async def _receive_loop(self):
+        """Reads and dispatches server messages until the socket closes."""
+        try:
+            async for raw in self.ws:
+                if self.stop_event.is_set():
+                    break
+                try:
+                    msg = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                await self._handle_message(msg)
+        except websockets.exceptions.ConnectionClosed:
+            if not self.stop_event.is_set():
+                print("⚠️ Unexpected 60db close, attempting reconnect...")
+                self.is_connected = False
+                asyncio.create_task(self._reconnect())
+        except Exception as e:
+            if not self.stop_event.is_set():
+                print(f"❌ 60db receive loop error: {e}")
+                self.is_connected = False
+                asyncio.create_task(self._reconnect())
+
+    async def _handle_message(self, msg):
+        """Routes a single decoded server message."""
+        if "connection_established" in msg:
+            return
+
+        if "session_started" in msg or msg.get("type") == "session_started":
+            self.is_connected = True
+            print("✅ 60db session started — ready for audio")
+            return
+
+        if "error" in msg or msg.get("type") == "error":
+            err = msg.get("error") or msg.get("message") or msg
+            print(f"❌ 60db error: {err}")
+            return
+
+        if msg.get("type") == "transcription":
+            await self._handle_transcription(msg)
+            return
+
+        # speech_started / session_stopped / billing summaries are not needed here.
+
+    async def _handle_transcription(self, msg):
+        if self.stop_event.is_set():
+            return
+
+        transcript = (msg.get("text") or "").strip()
+        # An empty final result signals rejected audio (silence / low confidence /
+        # hallucination guard) — skip it, exactly like an empty Deepgram transcript.
+        if not transcript:
+            return
+
+        is_final = bool(msg.get("is_final", False))
+        speech_final = bool(msg.get("speech_final", False))
+
+        # 60db does not provide a speaker index in non-diarized mode, so we default
+        # to speaker 0 (candidate) — the same default DeepgramManager uses.
+        speaker = msg.get("speaker", 0)
+        if speaker is None:
+            speaker = 0
+
+        # 60db can emit two-phase finals when context is supplied: a fast
+        # dict-corrected result (speech_final=False) followed by the LLM-refined
+        # canonical result (speech_final=True). Map ONLY the canonical result to the
+        # app's `is_final=True` so each utterance is processed exactly once; treat
+        # everything else as interim. Without context, both flags are True and this
+        # still yields a single final.
+        final = speech_final
+
+        data = {
+            "speaker": speaker,
+            "transcript": transcript,
+            "is_final": final,
+        }
+
+        if final:
+            print(f"✅ FINAL RESULT (60db): Speaker {speaker} - '{transcript}'")
+        await self.transcript_callback(data)
+
+    async def _reconnect(self):
+        """Attempt to reconnect to 60db with exponential backoff."""
+        if self.stop_event.is_set():
+            return
+        if self._reconnect_attempts >= self._max_reconnect_attempts:
+            print(f"❌ 60db: max reconnect attempts ({self._max_reconnect_attempts}) reached, giving up")
+            return
+
+        self._reconnect_attempts += 1
+        delay = self._reconnect_base_delay * (2 ** (self._reconnect_attempts - 1))
+        print(f"🔄 60db reconnect attempt {self._reconnect_attempts}/{self._max_reconnect_attempts} in {delay:.1f}s...")
+        await asyncio.sleep(delay)
+
+        if self.stop_event.is_set():
+            return
+
+        await self.start()
+
+    async def send_audio(self, audio_chunk, source='unknown'):
+        """Sends a raw PCM16 audio chunk to 60db as a base64 JSON frame."""
+        if not (self.is_connected and self.ws and not self.stop_event.is_set()):
+            return
+        try:
+            encoded = base64.b64encode(audio_chunk).decode("ascii")
+            await self.ws.send(json.dumps({
+                "type": "audio",
+                "audio": encoded,
+                "encoding": "linear",
+                "sample_rate": self.sample_rate,
+            }))
+        except websockets.exceptions.ConnectionClosed:
+            self.is_connected = False
+        except Exception as e:
+            print(f"❌ 60db send_audio error: {e}")
+
+    async def _safe_close(self):
+        if self.ws:
+            try:
+                await self.ws.close()
+            except Exception:
+                pass
+            self.ws = None
+
+    async def finish(self):
+        """Signals the connection to stop and closes it."""
+        print("🛑 Closing 60db connection...")
+        self.stop_event.set()
+        self.is_connected = False
+
+        if self.ws:
+            try:
+                await self.ws.send(json.dumps({"type": "stop"}))
+            except Exception:
+                pass
+            await self._safe_close()
+
+        if self._recv_task and not self._recv_task.done():
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except asyncio.CancelledError:
+                pass
+
+        print("✅ 60db connection closed successfully")

--- a/services/stt_service.py
+++ b/services/stt_service.py
@@ -36,6 +36,113 @@ async def verify_deepgram_api_key():
         return False
 
 
+def build_programming_keyterms(user_languages=None):
+    """
+    Build a deduplicated, language-prioritized list of programming/technical
+    keyterms used for STT phrase boosting.
+
+    Shared by Deepgram (joined into a keyterm string) and 60db (used as a
+    `context.terms` array) so both engines boost the same vocabulary and behave
+    consistently. Returns the full ordered list; callers slice to their own limit.
+    """
+    # Core programming concepts and algorithms
+    keyterms = [
+        # LeetCode and coding platforms
+        "LeetCode", "leetcode", "LeetCode problem", "HackerRank", "CodeSignal", "Codility",
+        "coding interview", "technical interview", "whiteboard", "online judge",
+
+        # Common algorithm problems (with variations)
+        "two sum", "2sum", "two-sum", "three sum", "3sum", "three-sum",
+        "four sum", "4sum", "four-sum", "valid parentheses", "merge intervals",
+        "climbing stairs", "house robber", "coin change", "longest substring",
+        "palindrome", "reverse linked list", "binary tree traversal",
+        "binary search", "depth first search", "DFS", "breadth first search", "BFS",
+        "dynamic programming", "DP", "greedy algorithm", "backtracking",
+        "sliding window", "two pointers", "fast slow pointers",
+
+        # Data structures
+        "linked list", "binary tree", "binary search tree", "BST",
+        "hash map", "hash table", "hash set", "array", "stack", "queue",
+        "heap", "priority queue", "trie", "graph", "adjacency list",
+        "adjacency matrix", "disjoint set", "union find",
+
+        # Programming languages
+        "Python", "Java", "JavaScript", "TypeScript", "C++", "C sharp",
+        "Go", "Rust", "Swift", "Kotlin", "Scala", "Ruby", "PHP",
+
+        # Common programming terms (with pronunciation variations)
+        "algorithm", "algorithms", "complexity", "time complexity", "space complexity",
+        "Big O", "big oh", "O of n", "O of log n", "O of n squared", "O of 1", "O one",
+        "recursion", "recursive", "iteration", "iterative", "memoization", "tabulation",
+        "optimization", "optimize", "brute force", "optimal solution", "suboptimal",
+        "amortized", "worst case", "best case", "average case",
+
+        # Technical interview terms
+        "edge case", "corner case", "test case", "unit test",
+        "refactor", "optimize", "debug", "runtime", "memory",
+        "scalability", "performance", "bottleneck",
+
+        # Common coding patterns
+        "singleton", "factory", "observer", "decorator", "adapter",
+        "strategy", "command", "facade", "proxy", "builder",
+
+        # Database and system design
+        "SQL", "NoSQL", "database", "schema", "index", "query",
+        "JOIN", "LEFT JOIN", "INNER JOIN", "GROUP BY", "ORDER BY",
+        "API", "REST", "GraphQL", "microservices", "monolith",
+        "load balancer", "cache", "Redis", "MongoDB", "PostgreSQL",
+
+        # Web development
+        "React", "Angular", "Vue", "Node.js", "Express", "Django",
+        "Flask", "Spring", "HTML", "CSS", "DOM", "JSON", "XML",
+        "HTTP", "HTTPS", "GET", "POST", "PUT", "DELETE",
+
+        # Common technical terms
+        "variable", "function", "method", "class", "object", "instance",
+        "inheritance", "polymorphism", "encapsulation", "abstraction",
+        "interface", "abstract", "static", "final", "const", "let", "var",
+        "async", "await", "promise", "callback", "closure", "scope",
+
+        # Numbers and common values
+        "zero", "one", "two", "three", "four", "five", "null", "undefined",
+        "true", "false", "boolean", "integer", "string", "float", "double"
+    ]
+
+    # Prioritize keyterms based on user's selected languages
+    prioritized_keyterms = []
+
+    # Add user's selected languages first (higher priority)
+    if user_languages:
+        for lang in user_languages:
+            lang_lower = lang.lower()
+            # Add language-specific terms first
+            if lang_lower == 'python':
+                prioritized_keyterms.extend(['Python', 'Django', 'Flask', 'pandas', 'numpy', 'pip', 'virtualenv'])
+            elif lang_lower == 'java':
+                prioritized_keyterms.extend(['Java', 'Spring', 'Maven', 'Gradle', 'JVM', 'JDK', 'servlet'])
+            elif lang_lower == 'javascript':
+                prioritized_keyterms.extend(['JavaScript', 'Node.js', 'React', 'Vue', 'Angular', 'npm', 'webpack'])
+            elif lang_lower == 'typescript':
+                prioritized_keyterms.extend(['TypeScript', 'interface', 'type', 'generic', 'decorator'])
+            elif lang_lower == 'c++':
+                prioritized_keyterms.extend(['C++', 'STL', 'vector', 'iterator', 'template', 'namespace'])
+            elif lang_lower == 'sql':
+                prioritized_keyterms.extend(['SQL', 'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'JOIN', 'WHERE'])
+
+    # Add general programming terms
+    prioritized_keyterms.extend(keyterms)
+
+    # Remove duplicates while preserving order
+    seen = set()
+    final_keyterms = []
+    for term in prioritized_keyterms:
+        if term not in seen:
+            seen.add(term)
+            final_keyterms.append(term)
+
+    return final_keyterms
+
+
 class DeepgramManager:
     """
     Manages the connection to Deepgram for live transcription.
@@ -65,101 +172,8 @@ class DeepgramManager:
         Limited to 500 tokens as per Deepgram requirements.
         Prioritizes terms based on user's selected programming languages.
         """
-        # Core programming concepts and algorithms
-        keyterms = [
-            # LeetCode and coding platforms
-            "LeetCode", "leetcode", "LeetCode problem", "HackerRank", "CodeSignal", "Codility",
-            "coding interview", "technical interview", "whiteboard", "online judge",
-            
-            # Common algorithm problems (with variations)
-            "two sum", "2sum", "two-sum", "three sum", "3sum", "three-sum", 
-            "four sum", "4sum", "four-sum", "valid parentheses", "merge intervals",
-            "climbing stairs", "house robber", "coin change", "longest substring",
-            "palindrome", "reverse linked list", "binary tree traversal",
-            "binary search", "depth first search", "DFS", "breadth first search", "BFS",
-            "dynamic programming", "DP", "greedy algorithm", "backtracking",
-            "sliding window", "two pointers", "fast slow pointers",
-            
-            # Data structures
-            "linked list", "binary tree", "binary search tree", "BST",
-            "hash map", "hash table", "hash set", "array", "stack", "queue",
-            "heap", "priority queue", "trie", "graph", "adjacency list",
-            "adjacency matrix", "disjoint set", "union find",
-            
-            # Programming languages
-            "Python", "Java", "JavaScript", "TypeScript", "C++", "C sharp",
-            "Go", "Rust", "Swift", "Kotlin", "Scala", "Ruby", "PHP",
-            
-            # Common programming terms (with pronunciation variations)
-            "algorithm", "algorithms", "complexity", "time complexity", "space complexity",
-            "Big O", "big oh", "O of n", "O of log n", "O of n squared", "O of 1", "O one",
-            "recursion", "recursive", "iteration", "iterative", "memoization", "tabulation",
-            "optimization", "optimize", "brute force", "optimal solution", "suboptimal",
-            "amortized", "worst case", "best case", "average case",
-            
-            # Technical interview terms
-            "edge case", "corner case", "test case", "unit test",
-            "refactor", "optimize", "debug", "runtime", "memory",
-            "scalability", "performance", "bottleneck",
-            
-            # Common coding patterns
-            "singleton", "factory", "observer", "decorator", "adapter",
-            "strategy", "command", "facade", "proxy", "builder",
-            
-            # Database and system design
-            "SQL", "NoSQL", "database", "schema", "index", "query",
-            "JOIN", "LEFT JOIN", "INNER JOIN", "GROUP BY", "ORDER BY",
-            "API", "REST", "GraphQL", "microservices", "monolith",
-            "load balancer", "cache", "Redis", "MongoDB", "PostgreSQL",
-            
-            # Web development
-            "React", "Angular", "Vue", "Node.js", "Express", "Django",
-            "Flask", "Spring", "HTML", "CSS", "DOM", "JSON", "XML",
-            "HTTP", "HTTPS", "GET", "POST", "PUT", "DELETE",
-            
-            # Common technical terms
-            "variable", "function", "method", "class", "object", "instance",
-            "inheritance", "polymorphism", "encapsulation", "abstraction",
-            "interface", "abstract", "static", "final", "const", "let", "var",
-            "async", "await", "promise", "callback", "closure", "scope",
-            
-            # Numbers and common values
-            "zero", "one", "two", "three", "four", "five", "null", "undefined",
-            "true", "false", "boolean", "integer", "string", "float", "double"
-        ]
-        
-        # Prioritize keyterms based on user's selected languages
-        prioritized_keyterms = []
-        
-        # Add user's selected languages first (higher priority)
-        if user_languages:
-            for lang in user_languages:
-                lang_lower = lang.lower()
-                # Add language-specific terms first
-                if lang_lower == 'python':
-                    prioritized_keyterms.extend(['Python', 'Django', 'Flask', 'pandas', 'numpy', 'pip', 'virtualenv'])
-                elif lang_lower == 'java':
-                    prioritized_keyterms.extend(['Java', 'Spring', 'Maven', 'Gradle', 'JVM', 'JDK', 'servlet'])
-                elif lang_lower == 'javascript':
-                    prioritized_keyterms.extend(['JavaScript', 'Node.js', 'React', 'Vue', 'Angular', 'npm', 'webpack'])
-                elif lang_lower == 'typescript':
-                    prioritized_keyterms.extend(['TypeScript', 'interface', 'type', 'generic', 'decorator'])
-                elif lang_lower == 'c++':
-                    prioritized_keyterms.extend(['C++', 'STL', 'vector', 'iterator', 'template', 'namespace'])
-                elif lang_lower == 'sql':
-                    prioritized_keyterms.extend(['SQL', 'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'JOIN', 'WHERE'])
-        
-        # Add general programming terms
-        prioritized_keyterms.extend(keyterms)
-        
-        # Remove duplicates while preserving order
-        seen = set()
-        final_keyterms = []
-        for term in prioritized_keyterms:
-            if term not in seen:
-                seen.add(term)
-                final_keyterms.append(term)
-        
+        final_keyterms = build_programming_keyterms(user_languages)
+
         # Join keyterms with proper URL encoding for multiple keyterms
         # Using space separation as recommended by Deepgram for phrase boosting
         # Limit to ensure we stay under 500 token limit (roughly 80-85 terms)

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -524,6 +524,28 @@ select:disabled {
     color: var(--accent-warning);
 }
 
+.ai-config-stt {
+    padding: var(--space-md);
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    border-radius: var(--radius-md);
+    position: relative;
+    border-left: 3px solid var(--accent-success);
+}
+
+.ai-config-stt h4 {
+    margin: 0 0 var(--space-sm) 0;
+    font-size: var(--font-sm);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--accent-success);
+}
+
+.ai-config-stt .ai-config-group {
+    grid-template-columns: 1fr;
+}
+
 .ai-config-group {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -693,6 +715,21 @@ select:disabled {
 }
 
 .deepgram-config h4 {
+    margin-top: 0;
+    color: var(--accent-success);
+    font-size: var(--font-sm);
+    text-transform: uppercase;
+}
+
+.sixtydb-config {
+    margin-bottom: var(--space-xl);
+    padding: var(--space-md);
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    border-radius: var(--radius-sm);
+}
+
+.sixtydb-config h4 {
     margin-top: 0;
     color: var(--accent-success);
     font-size: var(--font-sm);

--- a/web/index.html
+++ b/web/index.html
@@ -77,6 +77,18 @@
                     <fieldset>
                         <legend>AI Configuration</legend>
                         <div class="ai-config-section">
+                            <div class="ai-config-stt">
+                                <h4>Speech-to-Text Engine</h4>
+                                <div class="ai-config-group">
+                                    <select id="stt-engine-select" required>
+                                        <option value="deepgram">Deepgram (Nova-3)</option>
+                                        <option value="sixtydb">60db</option>
+                                    </select>
+                                </div>
+                                <small class="config-hint">Engine used for live transcription. Configure its API key
+                                    in the Advanced Config tab.</small>
+                            </div>
+
                             <div class="ai-config-primary">
                                 <h4>Primary AI Model (Default)</h4>
                                 <div class="ai-config-group">
@@ -188,6 +200,16 @@
                             <small class="config-hint">Stored in <code>.env</code> file</small>
                         </div>
 
+                        <div class="sixtydb-config">
+                            <h4>60db API (Speech-to-Text)</h4>
+                            <div class="config-row">
+                                <input type="password" id="adv-sixtydb-key" placeholder="SIXTYDB_API_KEY">
+                                <button id="save-sixtydb-btn" class="save-small">Save Key</button>
+                            </div>
+                            <small class="config-hint">Optional alternative STT engine. Stored in <code>.env</code>
+                                file</small>
+                        </div>
+
                         <div class="providers-table-container">
                             <table class="providers-table">
                                 <thead>
@@ -294,7 +316,7 @@
                     <select id="mic-select" disabled></select>
                 </div>
                 <div class="check-item" id="check-backend"><span class="indicator">⚪</span> Backend Connection</div>
-                <div class="check-item" id="check-deepgram"><span class="indicator">⚪</span> Deepgram API</div>
+                <div class="check-item" id="check-deepgram"><span class="indicator">⚪</span> Speech-to-Text API</div>
                 <div class="check-item" id="check-ai-provider"><span class="indicator">⚪</span> Primary AI Provider
                 </div>
                 <div class="check-item" id="check-ai-secondary-provider" style="display: none;"><span

--- a/web/js/config-manager.js
+++ b/web/js/config-manager.js
@@ -8,6 +8,8 @@ export class ConfigManager {
             providersList: document.getElementById('adv-providers-list'),
             deepgramKey: document.getElementById('adv-deepgram-key'),
             saveDeepgramBtn: document.getElementById('save-deepgram-btn'),
+            sixtydbKey: document.getElementById('adv-sixtydb-key'),
+            saveSixtydbBtn: document.getElementById('save-sixtydb-btn'),
             saveProvidersBtn: document.getElementById('save-all-providers-btn')
         };
 
@@ -34,6 +36,13 @@ export class ConfigManager {
                 this.elements.deepgramKey.value = dData.key || '';
             }
 
+            // Load 60db key
+            const sResp = await fetch('/api/sixtydb-key');
+            const sData = await sResp.json();
+            if (this.elements.sixtydbKey) {
+                this.elements.sixtydbKey.value = sData.key || '';
+            }
+
             this.renderProviders();
         } catch (error) {
             console.error('Failed to load advanced config data:', error);
@@ -43,6 +52,10 @@ export class ConfigManager {
     setupEventListeners() {
         if (this.elements.saveDeepgramBtn) {
             this.elements.saveDeepgramBtn.addEventListener('click', () => this.saveDeepgramKey());
+        }
+
+        if (this.elements.saveSixtydbBtn) {
+            this.elements.saveSixtydbBtn.addEventListener('click', () => this.saveSixtydbKey());
         }
 
         if (this.elements.saveProvidersBtn) {
@@ -207,6 +220,39 @@ export class ConfigManager {
             if (resp.ok) {
                 btn.textContent = '✅ Saved';
                 devLog('Deepgram key saved successfully');
+            } else {
+                btn.textContent = '❌ Failed';
+            }
+
+            setTimeout(() => {
+                btn.textContent = originalText;
+                btn.disabled = false;
+            }, 2000);
+        } catch (error) {
+            console.error('Save failed:', error);
+            btn.textContent = 'Error';
+            btn.disabled = false;
+        }
+    }
+
+    async saveSixtydbKey() {
+        const key = this.elements.sixtydbKey.value;
+        const btn = this.elements.saveSixtydbBtn;
+        const originalText = btn.textContent;
+
+        btn.textContent = 'Saving...';
+        btn.disabled = true;
+
+        try {
+            const resp = await fetch('/api/save-sixtydb-key', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ key })
+            });
+
+            if (resp.ok) {
+                btn.textContent = '✅ Saved';
+                devLog('60db key saved successfully');
             } else {
                 btn.textContent = '❌ Failed';
             }

--- a/web/js/provider-manager.js
+++ b/web/js/provider-manager.js
@@ -317,15 +317,19 @@ export class ProviderManager {
             devLog('No secondary vision provider selected, skipping verification');
         }
 
-        // This is a new, separate step to verify the Deepgram key.
-        this.verifyDeepgram();
-        
+        // This is a new, separate step to verify the selected STT engine's key.
+        this.verifySttEngine();
+
         await this.verifyAiProviders();
     }
 
-    verifyDeepgram() {
-        devLog("➡️ [Pre-Flight] Requesting Deepgram API verification...");
-        this.webSocketHandler.sendMessage('verify_deepgram', {});
+    verifySttEngine() {
+        const state = this.stateManager.getState();
+        const engine = state.selectedSttEngine || 'deepgram';
+        const label = engine === 'sixtydb' ? '60db' : 'Deepgram';
+        devLog(`➡️ [Pre-Flight] Requesting ${label} STT verification...`);
+        this.webSocketHandler.updateCheckStatus(this.checks.deepgram, 'pending', `Checking ${label}...`);
+        this.webSocketHandler.sendMessage('verify_stt', { engine });
     }
 
     async verifyAiProviders() {
@@ -383,10 +387,11 @@ export class ProviderManager {
 
     handleApiKeyStatus({ service, valid }) {
         devLog(`⬅️ [ProviderManager] Handling 'api_key_status' for ${service}. Valid: ${valid}`);
-        
-        if (service === 'deepgram') {
+
+        // Both STT engines report through the same pre-flight check element.
+        if (service === 'deepgram' || service === 'sixtydb') {
             const checkElement = this.checks.deepgram;
-            const serviceName = "Deepgram";
+            const serviceName = service === 'sixtydb' ? '60db' : 'Deepgram';
             if (valid) {
                 this.webSocketHandler.updateCheckStatus(checkElement, 'success', `${serviceName} API OK`);
             } else {

--- a/web/js/state-manager.js
+++ b/web/js/state-manager.js
@@ -24,6 +24,7 @@ export class StateManager {
                 model: null,
             },
             selectedLanguages: [],
+            selectedSttEngine: 'deepgram',
             currentPreset: null,
             availablePresets: [],
             systemStatus: null,
@@ -65,6 +66,7 @@ export class StateManager {
             visionModelSelect: document.getElementById('vision-model-select'),
             visionSecondaryProviderSelect: document.getElementById('vision-secondary-provider-select'),
             visionSecondaryModelSelect: document.getElementById('vision-secondary-model-select'),
+            sttEngineSelect: document.getElementById('stt-engine-select'),
             languageCheckboxes: document.querySelectorAll('input[name="language"]'),
         };
     }
@@ -170,6 +172,7 @@ export class StateManager {
         this.appState.selectedSecondaryVisionProvider.name = secondaryVisionProvider || null;
         this.appState.selectedSecondaryVisionProvider.model = secondaryVisionModel || null;
         this.appState.selectedLanguages = selectedLanguages;
+        this.appState.selectedSttEngine = this.onboardingForm.sttEngineSelect?.value || 'deepgram';
 
         devLog("Onboarding data captured:", this.appState);
         return true;

--- a/web/js/websocket-handler.js
+++ b/web/js/websocket-handler.js
@@ -300,6 +300,7 @@ export class WebSocketHandler {
                 model: state.selectedProvider.model
             },
             onboardingData: { ...state.onboardingData, selectedLanguages: state.selectedLanguages },
+            stt_engine: state.selectedSttEngine || 'deepgram',
             is_muted: initialMuteStatus.microphone,
             is_universally_muted: initialMuteStatus.universal,
             process_all_speakers: true,


### PR DESCRIPTION
What we added

  60db as a second, user-selectable speech-to-text engine alongside Deepgram. It streams audio over a WebSocket and feeds the exact
  same coaching pipeline.

  - New services/sixtydb_stt_service.py (SixtyDBManager — a drop-in twin of DeepgramManager)
  - Engine picker + 60db API-key field in the UI
  - Backend key endpoints, config (SIXTYDB_API_KEY), and websockets dependency
  - README updated

  How to use it

  1. pip install -r requirements.txt
  2. Launch Aura → Advanced Config tab → paste key in 60db API (Speech-to-Text) → Save Key (or set SIXTYDB_API_KEY in .env)
  3. Restart Aura (key loads at startup)
  4. AI Setup tab → Speech-to-Text Engine → select 60db
  5. Start Interview — pre-flight shows "60db API OK". Switch back to Deepgram anytime via the same dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an alternative speech-to-text engine (60db) alongside Deepgram
  * Users can now select their preferred speech-to-text provider for each interview session
  * Configuration interface updated to manage both Deepgram and 60db API credentials
  * Updated documentation with setup instructions for the new STT option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->