### PR TITLE
fix(macos): permission-dialog fixes, error surfacing, and native system-audio capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # ----- API Keys -----
 # Deepgram API key for Speech-to-Text
 # Get your key from: https://console.deepgram.com/
-DEEPGRAM_API_KEY="your_deepgram_api_key_here"
+DEEPGRAM_API_KEY=your_deepgram_api_key_here
 
 # ----- Logging -----
 LOG_LEVEL=INFO

--- a/MACOS_CRASH_FIX.md
+++ b/MACOS_CRASH_FIX.md
@@ -1,0 +1,150 @@
+# macOS AppKit Thread Safety Fix
+
+## The Problem
+
+Your application crashed with:
+```
+Exception Type: EXC_BREAKPOINT (SIGTRAP)
+Termination Reason: SIGNAL, Code 5, Trace/BPT trap: 5
+Application Specific Information: Must only be used from the main thread
+```
+
+**Root Cause**: The hotkey handler in `window_manager.py` was spawning background daemon threads to execute AppKit GUI operations. macOS AppKit is **not thread-safe** — all GUI operations must run on the main thread or the app will crash with a segfault.
+
+### The Problematic Code
+```python
+# OLD CODE (line ~540) — WRONG ❌
+def _on_key_down(event) -> None:
+    if action:
+        Thread(target=action, daemon=True).start()  # ← Spawns a background thread!
+```
+
+When the hotkey handler detected Option+Z, Option+X, or Option+1-3, it would spawn a daemon thread to call:
+- `toggle_visibility()` → calls `NSWindow.setVisible()` / `orderFrontRegardless()`
+- `toggle_ghost_mode()` → calls `NSWindow.setIgnoresMouseEvents_()`
+- `set_transparency()` → calls `NSWindow.setAlphaValue_()`
+
+All of these are AppKit methods that **must** run on macOS's main thread. Since they were being called from Thread-2 (the background hotkey thread), macOS immediately crashed with:
+```
+-[NSWMWindowCoordinator performTransactionUsingBlock:] + 752
+  ↓ (crash)
+```
+
+## The Solution
+
+### 1. Added a Main-Thread Dispatcher
+Created `_dispatch_to_main_thread(func, *args, **kwargs)` function that safely schedules AppKit operations to run on the main NSApplication thread:
+
+```python
+def _dispatch_to_main_thread(func, *args, **kwargs):
+    """Dispatch a callable to the main thread safely."""
+    if not IS_MACOS or NSApp is None:
+        return func(*args, **kwargs)
+    
+    try:
+        def _run_func():
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:
+                print(f"⚠️  Error in main-thread dispatch: {exc}")
+        
+        NSApp.performSelectorOnMainThread_withObject_waitUntilDone_(
+            "performSelector:withObject:",
+            (lambda: _run_func(),),
+            False
+        )
+    except Exception as exc:
+        print(f"⚠️  Could not dispatch to main thread: {exc}")
+        try:
+            func(*args, **kwargs)
+        except Exception:
+            pass
+```
+
+### 2. Updated Hotkey Action Map
+Wrapped all AppKit GUI operations with `_dispatch_to_main_thread`:
+
+```python
+_HOTKEY_ACTIONS: dict = {
+    'z': lambda: _dispatch_to_main_thread(self.toggle_visibility),      # ✅ GUI → main thread
+    'x': lambda: _dispatch_to_main_thread(self.toggle_ghost_mode),      # ✅ GUI → main thread
+    '1': lambda: _dispatch_to_main_thread(self.set_transparency, 1.0),  # ✅ GUI → main thread
+    '2': lambda: _dispatch_to_main_thread(self.set_transparency, 0.7),  # ✅ GUI → main thread
+    '3': lambda: _dispatch_to_main_thread(self.set_transparency, 0.4),  # ✅ GUI → main thread
+    'm': lambda: _send_command({"command": "toggle_mic_mute"}),        # ✅ File I/O (thread-safe)
+    'u': lambda: _send_command({"command": "toggle_universal_mute"}),  # ✅ File I/O (thread-safe)
+    # ... other command-based hotkeys remain thread-safe (they write JSON)
+}
+```
+
+### 3. Removed Background Thread Spawning
+The key-down handler now runs actions **directly** instead of spawning daemon threads:
+
+```python
+# NEW CODE ✅
+def _on_key_down(event) -> None:
+    if action:
+        action()  # Runs immediately — _dispatch_to_main_thread handles routing to main thread
+```
+
+## Why This Works
+
+1. **AppKit GUI operations (z, x, 1-3)**: 
+   - `_dispatch_to_main_thread` routes them to the main NSApplication event loop
+   - They execute safely on the main thread
+   - pywebview's event loop is already running, so this integrates seamlessly
+
+2. **Command-file operations (m, u, q, w, e, f, v, s, a, d, r)**:
+   - These are **thread-safe** — they just write JSON files to `/tmp/aura_command.json`
+   - `_send_command()` uses atomic `os.replace()` to prevent partial writes
+   - No need to dispatch to main thread
+   - Can run immediately from the hotkey handler
+
+## Testing the Fix
+
+1. **Rebuild and restart**:
+   ```bash
+   source venv/bin/activate
+   python main.py
+   ```
+
+2. **Test hotkeys**:
+   - Press **Option+Z** to toggle visibility
+   - Press **Option+X** to toggle ghost mode
+   - Press **Option+1/2/3** to change opacity
+   - These should now work without crashing
+
+3. **Test command hotkeys**:
+   - Press **Option+M** to mute microphone
+   - Press **Option+S** to capture screenshot
+   - These continue to work as before
+
+## Files Modified
+
+- [window_manager.py](window_manager.py):
+  - Added import: `from functools import partial`
+  - Added import: `NSRunLoop, NSTimer` from Foundation
+  - Added function: `_dispatch_to_main_thread()`
+  - Updated: `_HOTKEY_ACTIONS` to wrap GUI operations
+  - Updated: `_on_key_down()` to remove background thread spawning
+
+## Key Takeaways
+
+✅ **macOS AppKit requires all GUI operations on the main thread**
+- Cross-thread GUI calls → instant segfault/SIGTRAP
+- Solution: Use `NSApp.performSelectorOnMainThread_withObject_waitUntilDone_()`
+
+✅ **pywebview's NSApplication event loop is already running**
+- No need to manually start a CFRunLoop
+- No CFRunLoop conflicts with NSEvent monitors
+
+✅ **Mix thread-safe and GUI operations safely**
+- File I/O (JSON commands) → stay on hotkey thread (fast, safe)
+- Window manipulation → dispatch to main thread (required, safe)
+
+## References
+
+- [Apple AppKit Thread Safety](https://developer.apple.com/documentation/appkit/nsapplication)
+- [NSApplication.performSelectorOnMainThread_withObject_waitUntilDone_](https://developer.apple.com/documentation/appkit/nsapplication/1428537-performselectoronmainthread)
+- [pyobjc](https://pyobjc.readthedocs.io/)
+- [pywebview](https://pywebview.kivy.org/)

--- a/ai_providers.example.json
+++ b/ai_providers.example.json
@@ -2,7 +2,7 @@
     {
         "name": "Groq",
         "baseURL": "https://api.groq.com/openai/v1",
-        "apiKey": "YOUR_GROQ_API_KEY_HERE",
+        "apiKey": "YOUR_GROQ_API_KEY_1",
         "apiKeys": [
             "YOUR_GROQ_API_KEY_1",
             "YOUR_GROQ_API_KEY_2"
@@ -30,7 +30,7 @@
     {
         "name": "Cerebras",
         "baseURL": "https://api.cerebras.ai/v1",
-        "apiKey": "YOUR_CEREBRAS_API_KEY_HERE",
+        "apiKey": "YOUR_CEREBRAS_API_KEY_1",
         "apiKeys": [
             "YOUR_CEREBRAS_API_KEY_1",
             "YOUR_CEREBRAS_API_KEY_2"
@@ -51,7 +51,7 @@
     {
         "name": "Gemini",
         "baseURL": "https://generativelanguage.googleapis.com/v1beta/openai/",
-        "apiKey": "YOUR_GEMINI_API_KEY_HERE",
+        "apiKey": "YOUR_GEMINI_API_KEY_1",
         "apiKeys": [
             "YOUR_GEMINI_API_KEY_1",
             "YOUR_GEMINI_API_KEY_2"
@@ -77,9 +77,10 @@
     {
         "name": "OpenRouter",
         "baseURL": "https://openrouter.ai/api/v1",
-        "apiKey": "YOUR_OPENROUTER_API_KEY_HERE",
+        "apiKey": "YOUR_OPENROUTER_API_KEY_1",
         "apiKeys": [
-            "YOUR_OPENROUTER_API_KEY_1"
+            "YOUR_OPENROUTER_API_KEY_1",
+            "YOUR_OPENROUTER_API_KEY_2"
         ],
         "models": [
             {

--- a/api/session_manager.py
+++ b/api/session_manager.py
@@ -8,6 +8,7 @@ from .utils import send_json
 from services.llm_service import MultiLLMManager
 from services.stt_service import DeepgramManager
 from services.vision_service import vision_service
+from services.system_audio_capture import SystemAudioCapture
 
 # Session TTL: 30 minutes of inactivity with no WebSocket connected
 SESSION_TTL_SECONDS = 30 * 60
@@ -22,6 +23,8 @@ class InterviewSession:
         self.websocket: Optional[WebSocket] = None
         self.llm_manager: Optional[MultiLLMManager] = None
         self.stt_manager: Optional[DeepgramManager] = None
+        self.system_stt_manager: Optional[DeepgramManager] = None
+        self.system_audio_capture: Optional[SystemAudioCapture] = None
         self.is_active: bool = False
         self.state: Dict[str, any] = {
             "is_muted": False,
@@ -210,8 +213,30 @@ class InterviewSession:
         user_languages = onboarding_context.get('selectedLanguages', [])
         self.stt_manager = DeepgramManager(self.on_transcript, user_languages)
         await self.stt_manager.start()
-        
+
+        # Native system-audio capture (ScreenCaptureKit): hears whatever is
+        # playing on the whole system (e.g. a Zoom/Meet call), which WKWebView
+        # cannot expose via getDisplayMedia() on macOS. This gets its OWN
+        # Deepgram connection rather than sharing stt_manager's — mixing two
+        # independently-timed raw PCM streams into one connection would just
+        # interleave unrelated audio, not mix it, and corrupt transcription.
+        # `on_transcript` is source-agnostic (keyed off self.state, not which
+        # connection produced the transcript) so it's safe to reuse directly.
+        # Best-effort: if permission isn't granted or capture fails, the
+        # interview still works in mic-only mode exactly as before.
+        self.system_stt_manager = DeepgramManager(self.on_transcript, user_languages)
+        await self.system_stt_manager.start()
+
+        self.system_audio_capture = SystemAudioCapture()
+        await self.system_audio_capture.start(self._on_system_audio_chunk)
+
         self.is_active = True
+
+    def _on_system_audio_chunk(self, pcm_bytes: bytes):
+        """Callback from SystemAudioCapture — runs on the asyncio loop thread
+        (scheduled via call_soon_threadsafe), so it's safe to create a task."""
+        if self.system_stt_manager and not self.state.get("is_universally_muted", False):
+            asyncio.create_task(self.system_stt_manager.send_audio(pcm_bytes))
 
     async def _process_aggregated_transcript(self):
         """Processes the buffered transcript after a period of silence."""
@@ -238,7 +263,7 @@ class InterviewSession:
 
         except Exception as e:
             print(f"❌ CRITICAL: Error processing transcript for session {self.session_id}: {e}")
-            await self._send_json("error", {"message": "Error processing transcript."})
+            await self._send_json("error", {"message": f"Error processing transcript: {e}"})
 
     async def on_transcript(self, data):
         """Callback from Deepgram. Handles transcript logic and silence detection."""
@@ -272,6 +297,12 @@ class InterviewSession:
 
     async def cleanup(self):
         """Cleans up resources for the session."""
+        if self.system_audio_capture:
+            await self.system_audio_capture.stop()
+            self.system_audio_capture = None
+        if self.system_stt_manager:
+            await self.system_stt_manager.finish()
+            self.system_stt_manager = None
         if self.stt_manager:
             await self.stt_manager.finish()
         if self.silence_timer and not self.silence_timer.done():

--- a/macos/patch_python_permissions.sh
+++ b/macos/patch_python_permissions.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Adds NSMicrophoneUsageDescription / NSCameraUsageDescription to the Homebrew
+# python@3.14 framework's bundled Python.app.
+#
+# Why this is necessary: Aura runs as `python main.py`, but Homebrew's
+# framework Python unconditionally re-execs every invocation through its own
+# Resources/Python.app/Contents/MacOS/Python — this happens even for a
+# trivial `python3 -c "..."` with no GUI code involved. That means macOS's
+# TCC always attributes microphone/camera requests to that exact bundle
+# (org.python.python), no matter how Aura itself is launched or wrapped.
+# Without NSMicrophoneUsageDescription/NSCameraUsageDescription declared in
+# ITS Info.plist, TCC has no prompt text to show and silently denies access
+# instead of asking the user.
+#
+# Re-run this script whenever `brew upgrade/reinstall python@3.14` wipes the
+# keys back out (symptom: mic/camera permission denies with no system dialog,
+# and `plutil -p` on the path below no longer shows the two Usage keys).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REAL_PY="$("$PROJECT_ROOT/venv/bin/python3" -c 'import sys, os; print(os.path.realpath(sys.executable))')"
+FRAMEWORK_VERSION_DIR="$(dirname "$(dirname "$REAL_PY")")"   # .../Python.framework/Versions/3.14
+APP_BUNDLE="$FRAMEWORK_VERSION_DIR/Resources/Python.app"
+INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
+
+if [ ! -f "$INFO_PLIST" ]; then
+    echo "❌ Could not find Python.app Info.plist at: $INFO_PLIST"
+    exit 1
+fi
+
+echo "🔧 Patching: $INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Delete :NSMicrophoneUsageDescription" "$INFO_PLIST" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string Aura needs microphone access to transcribe your interview responses in real time." "$INFO_PLIST"
+
+/usr/libexec/PlistBuddy -c "Delete :NSCameraUsageDescription" "$INFO_PLIST" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :NSCameraUsageDescription string Aura needs camera access for upcoming video-based features." "$INFO_PLIST"
+
+echo "🔏 Re-signing: $APP_BUNDLE"
+codesign --force --deep --sign - "$APP_BUNDLE"
+
+echo "✅ Done. Fully quit Aura (and any running python main.py process) and relaunch to get the permission prompts."

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ import sys
 import socket
 import threading
 import shutil
+import platform
 from pathlib import Path
 
 
@@ -69,6 +70,89 @@ def find_free_port(preferred: int = 8002) -> int:
 # DEV_MODE is controlled via .env — see core/config.py
 DEV_MODE = settings.DEV_MODE
 print_config_debug()
+
+
+def _request_av_permission(media_type_name: str, label: str, emoji: str) -> None:
+    """Trigger the native macOS TCC permission dialog for a given AV media type.
+
+    getUserMedia() inside the WKWebView only surfaces WebKit's own prompt, which
+    is auto-granted by _AuraMicDelegate — it never touches the OS-level TCC
+    decision. Calling AVCaptureDevice.requestAccessForMediaType_ directly is
+    what actually makes macOS show the system "Aura Would Like to Access the
+    Microphone/Camera" dialog the first time the app runs.
+    """
+    try:
+        import AVFoundation
+
+        media_type = getattr(AVFoundation, media_type_name)
+        status = AVFoundation.AVCaptureDevice.authorizationStatusForMediaType_(media_type)
+        if status != 0:  # not AVAuthorizationStatusNotDetermined — already decided
+            print(f"{emoji} {label} authorization status: {status} (0=undetermined 1=restricted 2=denied 3=authorized)")
+            return
+
+        def _on_decided(granted: bool) -> None:
+            print(f"{emoji} {label} permission {'granted' if granted else 'denied'} by user")
+
+        print(f"{emoji} Requesting {label.lower()} permission…")
+        AVFoundation.AVCaptureDevice.requestAccessForMediaType_completionHandler_(media_type, _on_decided)
+    except Exception as exc:
+        print(f"⚠️ Could not request {label.lower()} permission: {exc}")
+
+
+def request_microphone_permission() -> None:
+    """Trigger the native macOS microphone permission dialog immediately at launch."""
+    if platform.system() != "Darwin":
+        return
+    _request_av_permission("AVMediaTypeAudio", "Microphone", "🎙️")
+
+
+def request_camera_permission() -> None:
+    """Trigger the native macOS camera permission dialog immediately at launch.
+
+    Aura doesn't use the camera today (vision mode captures the screen via
+    getDisplayMedia, not getUserMedia video), but this pre-authorizes it so a
+    future camera feature doesn't need its own first-run prompt path.
+    """
+    if platform.system() != "Darwin":
+        return
+    _request_av_permission("AVMediaTypeVideo", "Camera", "📷")
+
+
+def request_screen_recording_permission() -> None:
+    """Trigger the native macOS Screen Recording permission dialog immediately
+    at launch. This is what lets Aura hear system/meeting audio (see
+    services/system_audio_capture.py) — WKWebView cannot capture system audio
+    on macOS at all, so this is the only way to hear the interviewer's side
+    of a call.
+
+    Unlike mic/camera, granting Screen Recording does NOT take effect for an
+    already-running process — the user must fully quit and relaunch Aura
+    after clicking Allow for system-audio capture to actually start working.
+    """
+    if platform.system() != "Darwin":
+        return
+    try:
+        from services.system_audio_capture import (
+            has_screen_recording_permission,
+            request_screen_recording_permission as _request,
+        )
+
+        if has_screen_recording_permission():
+            print("🖥️ Screen Recording permission already granted (system audio capture available)")
+            return
+
+        print("🖥️ Requesting Screen Recording permission (for system/meeting audio capture)…")
+        _request()
+        print("   ℹ️ If you just granted it, fully quit and relaunch Aura for system audio to start working.")
+    except Exception as exc:
+        print(f"⚠️ Could not request Screen Recording permission: {exc}")
+
+
+# Note: there is no macOS TCC permission for audio *output* ("speaker").
+# Apps can play sound freely — only capture (microphone/camera) and a few
+# other sensitive categories (screen recording, input monitoring, etc.) are
+# gated. If audio isn't coming out, it's a device-selection/routing issue,
+# not a permission one — see window_manager for output device handling.
 
 
 # --- Global Command Monitor ---
@@ -378,7 +462,10 @@ def setup_webview_window():
 
         if not DEV_MODE:
             print("🛡️ Applying screen capture protection…")
-            ok = window_manager.apply_capture_protection(win)
+            # win.events.shown fires on a pywebview-internal background thread,
+            # but AppKit calls (NSWindow.setSharingType_ etc.) must run on the
+            # main thread or macOS raises SIGTRAP.
+            ok = window_manager._dispatch_to_main_thread(window_manager.apply_capture_protection, win)
             if ok:
                 print("✅ Screen capture protection applied!")
             else:
@@ -395,7 +482,7 @@ def setup_webview_window():
 
             # Always-on-top (NSFloatingWindowLevel)
             for attempt in range(3):
-                if window_manager.set_app_always_on_top(True):
+                if window_manager._dispatch_to_main_thread(window_manager.set_app_always_on_top, True):
                     print("📌 Window set to always-on-top")
                     break
                 print(f"⚠️ Always-on-top attempt {attempt + 1} failed, retrying…")
@@ -449,20 +536,25 @@ def setup_webview_window():
                         return found
                 return None
 
-            mic_delegate = _AuraMicDelegate.alloc().init()
-            for ns_window in NSApp.windows():
-                content = ns_window.contentView()
-                if content is None:
-                    continue
-                wkview = _find_wkwebview(content)
-                if wkview:
-                    # Remove gesture restriction for playback too
-                    wkview.configuration().setMediaTypesRequiringUserActionForPlayback_(0)
-                    wkview.setUIDelegate_(mic_delegate)
-                    # Pin to prevent garbage collection
-                    win._mic_delegate = mic_delegate
-                    print("🎙️ WKUIDelegate set — microphone will be auto-granted")
-                    break
+            def _install_mic_delegate():
+                # NSApp.windows()/contentView()/setUIDelegate_ etc. are AppKit
+                # calls and must run on the main thread.
+                mic_delegate = _AuraMicDelegate.alloc().init()
+                for ns_window in NSApp.windows():
+                    content = ns_window.contentView()
+                    if content is None:
+                        continue
+                    wkview = _find_wkwebview(content)
+                    if wkview:
+                        # Remove gesture restriction for playback too
+                        wkview.configuration().setMediaTypesRequiringUserActionForPlayback_(0)
+                        wkview.setUIDelegate_(mic_delegate)
+                        # Pin to prevent garbage collection
+                        win._mic_delegate = mic_delegate
+                        print("🎙️ WKUIDelegate set — microphone will be auto-granted")
+                        break
+
+            window_manager._dispatch_to_main_thread(_install_mic_delegate)
         except Exception as mic_exc:
             print(f"ℹ️ WKUIDelegate setup failed: {mic_exc}")
 
@@ -485,6 +577,10 @@ def main():
     """Application entry point: start async services, open pywebview window, run Cocoa loop."""
     print("🚀 Starting Aura (macOS — AppKit/Cocoa)")
     print("   📋 Architecture: pywebview/Cocoa on main thread, asyncio in background thread")
+
+    request_microphone_permission()
+    request_camera_permission()
+    request_screen_recording_permission()
 
     try:
         asyncio_service_thread.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ pywebview
 pyobjc-core
 pyobjc-framework-Cocoa
 pyobjc-framework-Quartz
+pyobjc-framework-AVFoundation
+pyobjc-framework-ScreenCaptureKit
+pyobjc-framework-CoreMedia
 
 # Web server
 fastapi

--- a/services/system_audio_capture.py
+++ b/services/system_audio_capture.py
@@ -1,0 +1,227 @@
+# services/system_audio_capture.py — native macOS system-audio capture.
+#
+# WKWebView's getDisplayMedia() does not expose system audio on macOS (only
+# screen video is returned — see web/js/audio_handler.js's fallback to
+# "mic-only mode"), so there is no way to hear a meeting app's audio (Zoom,
+# Meet, Teams, ...) through the browser layer at all. This module captures
+# whole-system audio output directly via ScreenCaptureKit (macOS 13+) and
+# feeds it straight into the existing Deepgram pipeline, bypassing the
+# WebSocket/frontend entirely.
+import array
+import asyncio
+import platform
+from typing import Callable, Optional
+
+IS_MACOS = platform.system() == "Darwin"
+
+if IS_MACOS:
+    import objc
+    from Foundation import NSObject
+    import ScreenCaptureKit as SCK
+    import CoreMedia as CM
+    import Quartz
+else:
+    NSObject = object
+    SCK = None
+    CM = None
+    Quartz = None
+
+# Must match services/stt_service.py LiveOptions (encoding="linear16").
+SAMPLE_RATE = 48000
+CHANNEL_COUNT = 1
+
+
+def has_screen_recording_permission() -> bool:
+    """Check current Screen Recording (TCC) authorization without prompting."""
+    if not IS_MACOS:
+        return False
+    return bool(Quartz.CGPreflightScreenCaptureAccess())
+
+
+def request_screen_recording_permission() -> bool:
+    """Trigger the native macOS Screen Recording permission dialog.
+
+    Unlike mic/camera, granting this for an already-running process does NOT
+    take effect until the app is fully quit and relaunched — that's a macOS
+    quirk specific to Screen Recording, not a bug here.
+    """
+    if not IS_MACOS:
+        return False
+    return bool(Quartz.CGRequestScreenCaptureAccess())
+
+
+def _extract_pcm16(sample_buffer) -> bytes:
+    """Extract interleaved PCM from a CMSampleBuffer and convert Float32 -> Int16.
+
+    ScreenCaptureKit always delivers audio as 32-bit float PCM (there is no
+    bit-depth option on SCStreamConfiguration); Deepgram expects 16-bit
+    linear PCM, so we convert here the same way the browser's AudioWorklet
+    already does for mic/browser-captured audio (web/js/audio_processor.js).
+    """
+    block_buffer = CM.CMSampleBufferGetDataBuffer(sample_buffer)
+    if not block_buffer:
+        return b""
+    length = CM.CMBlockBufferGetDataLength(block_buffer)
+    if length <= 0:
+        return b""
+    status, raw_bytes = CM.CMBlockBufferCopyDataBytes(block_buffer, 0, length, None)
+    if status != 0 or not raw_bytes:
+        return b""
+
+    floats = array.array("f")
+    floats.frombytes(bytes(raw_bytes))
+
+    pcm16 = array.array("h", bytes(len(floats) * 2))
+    for i, sample in enumerate(floats):
+        clamped = max(-1.0, min(1.0, sample))
+        pcm16[i] = int(clamped * 32767)
+    return pcm16.tobytes()
+
+
+if IS_MACOS:
+
+    class _SystemAudioStreamOutput(NSObject):
+        """SCStreamOutput/SCStreamDelegate — receives raw audio sample buffers
+        on an internal ScreenCaptureKit thread and hands PCM back to asyncio."""
+
+        def initWithCallback_loop_(self, on_pcm_chunk, loop):
+            self = objc.super(_SystemAudioStreamOutput, self).init()
+            if self is None:
+                return None
+            self._on_pcm_chunk = on_pcm_chunk
+            self._loop = loop
+            return self
+
+        def stream_didOutputSampleBuffer_ofType_(self, stream, sample_buffer, of_type):
+            if of_type != SCK.SCStreamOutputTypeAudio:
+                return
+            try:
+                pcm16 = _extract_pcm16(sample_buffer)
+            except Exception as exc:
+                print(f"⚠️ System audio: failed to extract PCM from sample buffer: {exc}")
+                return
+            if pcm16 and self._loop and not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(self._on_pcm_chunk, pcm16)
+
+        def stream_didStopWithError_(self, stream, error):
+            print(f"⚠️ System audio capture stopped by the system: {error}")
+
+
+class SystemAudioCapture:
+    """Captures whole-system audio output and delivers 16-bit PCM chunks."""
+
+    def __init__(self):
+        self._stream = None
+        self._output = None
+        self._running = False
+
+    async def start(self, on_pcm_chunk: Callable[[bytes], None]) -> bool:
+        """Start capturing system audio. Returns False (never raises) on any
+        failure — system audio is a best-effort enhancement, not required for
+        the interview to function (mic-only still works without it)."""
+        if not IS_MACOS:
+            return False
+        if not has_screen_recording_permission():
+            print("⚠️ System audio capture: Screen Recording permission not granted — skipping.")
+            print("   Grant it in System Settings → Privacy & Security → Screen Recording, then fully restart Aura.")
+            return False
+
+        loop = asyncio.get_event_loop()
+        try:
+            content = await self._get_shareable_content(loop)
+            displays = content.displays()
+            if not displays:
+                print("⚠️ System audio capture: no displays found.")
+                return False
+            display = displays[0]
+
+            content_filter = SCK.SCContentFilter.alloc().initWithDisplay_excludingWindows_(display, [])
+
+            config = SCK.SCStreamConfiguration.alloc().init()
+            config.setCapturesAudio_(True)
+            config.setExcludesCurrentProcessAudio_(True)
+            config.setSampleRate_(SAMPLE_RATE)
+            config.setChannelCount_(CHANNEL_COUNT)
+            # We only want audio — minimize video capture overhead.
+            config.setWidth_(2)
+            config.setHeight_(2)
+            config.setShowsCursor_(False)
+
+            self._output = _SystemAudioStreamOutput.alloc().initWithCallback_loop_(on_pcm_chunk, loop)
+            self._stream = SCK.SCStream.alloc().initWithFilter_configuration_delegate_(
+                content_filter, config, self._output
+            )
+
+            ok, error = self._stream.addStreamOutput_type_sampleHandlerQueue_error_(
+                self._output, SCK.SCStreamOutputTypeAudio, None, None
+            )
+            if not ok:
+                print(f"❌ System audio capture: failed to add stream output: {error}")
+                return False
+
+            started = await self._start_capture()
+            if not started:
+                return False
+
+            self._running = True
+            print("🔊 System audio capture started (ScreenCaptureKit)")
+            return True
+        except Exception as exc:
+            print(f"❌ System audio capture failed to start: {exc}")
+            return False
+
+    async def _get_shareable_content(self, loop):
+        future = loop.create_future()
+
+        def handler(content, error):
+            def _resolve():
+                if future.done():
+                    return
+                if error is not None:
+                    future.set_exception(RuntimeError(str(error)))
+                else:
+                    future.set_result(content)
+            loop.call_soon_threadsafe(_resolve)
+
+        SCK.SCShareableContent.getShareableContentWithCompletionHandler_(handler)
+        return await future
+
+    async def _start_capture(self) -> bool:
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+
+        def handler(error):
+            def _resolve():
+                if not future.done():
+                    future.set_result(error)
+            loop.call_soon_threadsafe(_resolve)
+
+        self._stream.startCaptureWithCompletionHandler_(handler)
+        error = await future
+        if error is not None:
+            print(f"❌ System audio capture: startCaptureWithCompletionHandler error: {error}")
+            return False
+        return True
+
+    async def stop(self):
+        if not self._stream or not self._running:
+            return
+        self._running = False
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+
+        def handler(error):
+            def _resolve():
+                if not future.done():
+                    future.set_result(error)
+            loop.call_soon_threadsafe(_resolve)
+
+        try:
+            self._stream.stopCaptureWithCompletionHandler_(handler)
+            await asyncio.wait_for(future, timeout=5.0)
+        except Exception as exc:
+            print(f"⚠️ Error stopping system audio capture: {exc}")
+        finally:
+            self._stream = None
+            self._output = None
+            print("🔇 System audio capture stopped")

--- a/web/js/preset-manager.js
+++ b/web/js/preset-manager.js
@@ -341,9 +341,8 @@ class PresetManager {
         this.showNotification(title, message, details, type, healthResults);
     }
     
-    showErrorNotification(error, data = {}) {
-        const title = '❌ Preset Switch Failed';
-        const message = typeof error === 'string' ? error : 'Failed to switch AI model';
+    showErrorNotification(error, data = {}, title = '❌ Error') {
+        const message = typeof error === 'string' ? error : 'An unexpected error occurred';
         const details = data.available_presets ? 
             `Available presets: ${data.available_presets.join(', ')}` : 
             'Please check your configuration';

--- a/web/js/websocket-handler.js
+++ b/web/js/websocket-handler.js
@@ -235,7 +235,7 @@ export class WebSocketHandler {
 
     handlePresetSwitchFailed(payload) {
         if (window.presetManager) {
-            presetManager.showErrorNotification(payload.error, payload);
+            presetManager.showErrorNotification(payload.error, payload, '❌ Preset Switch Failed');
         }
     }
     

--- a/window_manager.py
+++ b/window_manager.py
@@ -15,8 +15,10 @@ import os
 import platform
 import time
 import tempfile
+import threading
 from typing import Optional
 from threading import Thread
+from functools import partial
 
 import orjson
 import webview
@@ -78,7 +80,8 @@ if IS_MACOS:
         NSNormalWindowLevel,
         NSWindowSharingNone,
     )
-    from Foundation import NSPoint
+    from Foundation import NSPoint, NSRunLoop, NSTimer
+    from PyObjCTools import AppHelper
 else:
     # Graceful degradation if somehow imported on another platform
     NSApp = None
@@ -86,6 +89,58 @@ else:
     NSNormalWindowLevel = 0
     NSWindowSharingNone = 0
     NSPoint = None
+    NSRunLoop = None
+    NSTimer = None
+    AppHelper = None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main-thread dispatcher for AppKit operations
+# ─────────────────────────────────────────────────────────────────────────────
+def _dispatch_to_main_thread(func, *args, **kwargs):
+    """
+    Run a callable on the main thread and return its result.
+    AppKit operations (NSWindow, NSApp, WKWebView, ...) MUST run on the main
+    thread — calling them from a background thread (e.g. pywebview's
+    `shown`/hotkey callbacks) raises SIGTRAP ("Must only be used from the
+    main thread") on modern macOS.
+
+    Uses PyObjCTools.AppHelper.callAfter, which schedules the call on the
+    main run loop, and blocks the calling thread until it has run so the
+    return value (or exception) can be propagated back synchronously.
+    """
+    if not IS_MACOS or NSApp is None or AppHelper is None:
+        # Not on macOS or AppKit not available — run directly
+        return func(*args, **kwargs)
+
+    if threading.current_thread() is threading.main_thread():
+        # Already on the main thread — no dispatch needed
+        return func(*args, **kwargs)
+
+    done = threading.Event()
+    outcome = {}
+
+    def _run_on_main():
+        try:
+            outcome["result"] = func(*args, **kwargs)
+        except Exception as exc:
+            outcome["error"] = exc
+        finally:
+            done.set()
+
+    try:
+        AppHelper.callAfter(_run_on_main)
+    except Exception as exc:
+        print(f"⚠️  Could not dispatch to main thread: {exc}")
+        return func(*args, **kwargs)
+
+    if not done.wait(timeout=5.0):
+        print("⚠️  Main-thread dispatch timed out")
+        return None
+    if "error" in outcome:
+        print(f"⚠️  Error in main-thread dispatch: {outcome['error']}")
+        return None
+    return outcome.get("result")
 
 
 # ---------------------------------------------------------------------------
@@ -434,12 +489,14 @@ class WindowManager:
                 print(f"⚠️  Could not write hotkey command: {exc}")
 
         # ── Action map keyed by base character ───────────────────────────
+        # CRITICAL: All AppKit operations (z, x, 1, 2, 3) MUST run on main thread!
+        # Command-file operations (m, u, q, w, e, f, v, s, a, d, r) are thread-safe.
         _HOTKEY_ACTIONS: dict = {
-            'z': lambda: self.toggle_visibility(),
-            'x': lambda: self.toggle_ghost_mode(),
-            '1': lambda: self.set_transparency(1.0),
-            '2': lambda: self.set_transparency(0.7),
-            '3': lambda: self.set_transparency(0.4),
+            'z': lambda: _dispatch_to_main_thread(self.toggle_visibility),
+            'x': lambda: _dispatch_to_main_thread(self.toggle_ghost_mode),
+            '1': lambda: _dispatch_to_main_thread(self.set_transparency, 1.0),
+            '2': lambda: _dispatch_to_main_thread(self.set_transparency, 0.7),
+            '3': lambda: _dispatch_to_main_thread(self.set_transparency, 0.4),
             'm': lambda: _send_command({"command": "toggle_mic_mute"}),
             'u': lambda: _send_command({"command": "toggle_universal_mute"}),
             'q': lambda: _send_command({"command": "switch_preset", "preset_key": "primary"}),
@@ -462,7 +519,13 @@ class WindowManager:
 
         # ── Key-down handler ─────────────────────────────────────────────
         def _on_key_down(event) -> None:
-            """Dispatch hotkeys and start scroll on ⌥↑ / ⌥↓."""
+            """Dispatch hotkeys and start scroll on ⌥↑ / ⌥↓.
+            
+            CRITICAL: AppKit window operations MUST run on the main thread!
+            For GUI operations (z, x, 1-3), we dispatch to main thread.
+            For file-based commands (m, u, q, w, e, f, v, s, a, d, r),
+            we can safely run on a background thread since they only write JSON files.
+            """
             if not (event.modifierFlags() & _NSAltKeyMask):
                 return
 
@@ -482,7 +545,9 @@ class WindowManager:
             if chars:
                 action = _HOTKEY_ACTIONS.get(chars.lower())
                 if action:
-                    Thread(target=action, daemon=True).start()
+                    # Run the action directly — _dispatch_to_main_thread handles
+                    # AppKit operations, and file-write commands are thread-safe
+                    action()
 
         # ── Key-up handler ───────────────────────────────────────────────
         def _on_key_up(event) -> None:


### PR DESCRIPTION
## Summary

A few macOS-specific fixes/additions built while running the `macos` branch day-to-day:

- **Mic/camera permission dialogs never appeared.** `getUserMedia()` in WKWebView only triggers WebKit's own auto-granted prompt (`_AuraMicDelegate`) — it never touches the OS-level TCC decision, and the Homebrew Python.app bundle had no `NSMicrophoneUsageDescription`/`NSCameraUsageDescription`. Added `request_microphone_permission()`/`request_camera_permission()` in `main.py` (using `AVCaptureDevice.requestAccessForMediaType_completionHandler_`) plus `macos/patch_python_permissions.sh`, which patches the actual Info.plist that every `python main.py` invocation runs through (Homebrew's framework Python always re-execs into its own bundled `Python.app`, so this is the one place that needs the usage-description keys) and re-signs it. See `MACOS_CRASH_FIX.md` for the background on the AppKit main-thread issue this builds on.
- **Generic "error" toast with no detail.** Any failure in `_process_aggregated_transcript` (`api/session_manager.py`) was swallowed into a hardcoded "Error processing transcript." string, and the frontend (`preset-manager.js`/`websocket-handler.js`) mislabeled every generic error as "❌ Preset Switch Failed" (reusing the preset-switch-failure notification for unrelated errors). Now the real exception message is sent to the client, and the toast title only says "Preset Switch Failed" when that's actually what happened.
- **No system/meeting audio capture.** WKWebView's `getDisplayMedia()` does not expose system audio on macOS at all (screen video only) — there is no way to hear a meeting app's audio through the browser layer. Added `services/system_audio_capture.py`, which captures whole-system audio via ScreenCaptureKit (`SCStream`, macOS 13+) and feeds it into its own dedicated Deepgram connection in `session_manager.py` (kept separate from the mic's connection deliberately — interleaving two independently-timed raw PCM streams into one connection would corrupt transcription rather than mix it). Requires Screen Recording permission, requested via `request_screen_recording_permission()` in `main.py`.

## Test plan

- [x] Verified mic/camera `AVCaptureDevice.authorizationStatusForMediaType_` triggers a real system dialog after patching Python.app's Info.plist.
- [x] Verified system-audio capture end-to-end with a live `SCStream` capture test (silence → strong signal while `say` spoke through system audio output).
- [ ] Would appreciate a maintainer's eyes on `macos/patch_python_permissions.sh` — it modifies the Homebrew-installed Python.framework bundle outside the repo, which is a bit unusual; happy to discuss alternatives (e.g. a proper py2app bundle) if that's preferred long-term.